### PR TITLE
Ignore telephone links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Ignore "tel:" links.
+  [tmassman]
 
 
 1.5 (2017-10-10)

--- a/src/collective/linkcheck/browser.py
+++ b/src/collective/linkcheck/browser.py
@@ -96,6 +96,10 @@ class CheckLinks(BrowserView):
             if href.startswith('mailto:'):
                 continue
 
+            # Ignore tel links
+            if href.startswith('tel:'):
+                continue
+
             # handle relative urls
             if href.startswith('.') or (
                     not href.startswith('/') and

--- a/src/collective/linkcheck/events.py
+++ b/src/collective/linkcheck/events.py
@@ -120,6 +120,10 @@ def end_request(event):
         if href.startswith('mailto:'):
             continue
 
+        # Ignore tel links
+        if href.startswith('tel:'):
+            continue
+
         # handle relative urls
         if href.startswith('.') or (
                 not href.startswith('/') and


### PR DESCRIPTION
Do not parse links starting with "tel:" which are valid href attributes like "mailto:".